### PR TITLE
Add audited gem to track record changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,9 @@ ruby '3.0.2'
 # Runtime type checking for Ruby
 gem 'sorbet-runtime'
 
+# Produce audit logs for record changes
+gem 'audited', '~> 5.0'
+
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'rails', '~> 7.0.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,8 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    audited (5.0.2)
+      activerecord (>= 5.0, < 7.1)
     bindex (0.8.1)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
@@ -274,6 +276,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  audited (~> 5.0)
   bootsnap
   capybara
   debug

--- a/app/models/abbreviation.rb
+++ b/app/models/abbreviation.rb
@@ -2,4 +2,6 @@
 
 class Abbreviation < ApplicationRecord
   belongs_to :dictionary_entry
+
+  audited associated_with: :dictionary_entry
 end

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -2,4 +2,7 @@
 
 class Brand < ApplicationRecord
   has_many :brand_aliases, dependent: :destroy
+  has_associated_audits
+
+  audited
 end

--- a/app/models/brand_alias.rb
+++ b/app/models/brand_alias.rb
@@ -2,4 +2,6 @@
 
 class BrandAlias < ApplicationRecord
   belongs_to :brand
+
+  audited associated_with: :brand
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,4 +2,6 @@
 
 class Comment < ApplicationRecord
   # belongs_to :user
+
+  audited
 end

--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -2,4 +2,7 @@
 
 class DictionaryEntry < ApplicationRecord
   has_many :abbreviations, dependent: :destroy
+  has_associated_audits
+
+  audited
 end

--- a/app/models/item_measure.rb
+++ b/app/models/item_measure.rb
@@ -2,4 +2,7 @@
 
 class ItemMeasure < ApplicationRecord
   has_many :item_measure_aliases, dependent: :destroy
+  has_associated_audits
+
+  audited
 end

--- a/app/models/item_measure_alias.rb
+++ b/app/models/item_measure_alias.rb
@@ -2,4 +2,6 @@
 
 class ItemMeasureAlias < ApplicationRecord
   belongs_to :item_measure
+
+  audited associated_with: :item_measure
 end

--- a/app/models/item_pack.rb
+++ b/app/models/item_pack.rb
@@ -2,4 +2,7 @@
 
 class ItemPack < ApplicationRecord
   has_many :item_pack_aliases, dependent: :destroy
+  has_associated_audits
+
+  audited
 end

--- a/app/models/item_pack_alias.rb
+++ b/app/models/item_pack_alias.rb
@@ -2,4 +2,6 @@
 
 class ItemPackAlias < ApplicationRecord
   belongs_to :item_pack
+
+  audited associated_with: :item_pack
 end

--- a/app/models/item_sell_pack.rb
+++ b/app/models/item_sell_pack.rb
@@ -2,4 +2,7 @@
 
 class ItemSellPack < ApplicationRecord
   has_many :item_sell_pack_aliases, dependent: :destroy
+  has_associated_audits
+
+  audited
 end

--- a/app/models/item_sell_pack_alias.rb
+++ b/app/models/item_sell_pack_alias.rb
@@ -2,4 +2,6 @@
 
 class ItemSellPackAlias < ApplicationRecord
   belongs_to :item_sell_pack
+
+  audited associated_with: :item_sell_pack
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,4 +2,7 @@
 
 class Product < ApplicationRecord
   has_many :product_duplicates, dependent: :destroy
+  has_associated_audits
+
+  audited
 end

--- a/app/models/product_duplicate.rb
+++ b/app/models/product_duplicate.rb
@@ -4,4 +4,6 @@ class ProductDuplicate < ApplicationRecord
   belongs_to :product
   # belongs_to :canonical_product
   # belongs_to :mapped_product
+
+  audited associated_with: :product
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
+  audited
 end

--- a/db/migrate/20220613100016_install_audited.rb
+++ b/db/migrate/20220613100016_install_audited.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class InstallAudited < ActiveRecord::Migration[7.0]
+  def self.up
+    create_table :audits, :force => true do |t|
+      t.column :auditable_id, :integer
+      t.column :auditable_type, :string
+      t.column :associated_id, :integer
+      t.column :associated_type, :string
+      t.column :user_id, :integer
+      t.column :user_type, :string
+      t.column :username, :string
+      t.column :action, :string
+      t.column :audited_changes, :jsonb
+      t.column :version, :integer, :default => 0
+      t.column :comment, :string
+      t.column :remote_address, :string
+      t.column :request_uuid, :string
+      t.column :created_at, :datetime
+    end
+
+    add_index :audits, [:auditable_type, :auditable_id, :version], :name => 'auditable_index'
+    add_index :audits, [:associated_type, :associated_id], :name => 'associated_index'
+    add_index :audits, [:user_id, :user_type], :name => 'user_index'
+    add_index :audits, :request_uuid
+    add_index :audits, :created_at
+  end
+
+  def self.down
+    drop_table :audits
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,165 +10,187 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_220_609_124_659) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_13_100016) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'abbreviations', force: :cascade do |t|
-    t.bigint('dictionary_entry_id', null: false)
-    t.string('letters')
-    t.datetime('created_at', null: false)
-    t.datetime('updated_at', null: false)
-    t.index(['dictionary_entry_id'], name: 'index_abbreviations_on_dictionary_entry_id')
+  create_table "abbreviations", force: :cascade do |t|
+    t.bigint "dictionary_entry_id", null: false
+    t.string "letters"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["dictionary_entry_id"], name: "index_abbreviations_on_dictionary_entry_id"
   end
 
-  create_table 'brand_aliases', force: :cascade do |t|
-    t.bigint('brand_id', null: false)
-    t.string('alias')
-    t.boolean('confirmed', default: false)
-    t.integer('count')
-    t.datetime('created_at', null: false)
-    t.datetime('updated_at', null: false)
-    t.index(['brand_id'], name: 'index_brand_aliases_on_brand_id')
+  create_table "audits", force: :cascade do |t|
+    t.integer "auditable_id"
+    t.string "auditable_type"
+    t.integer "associated_id"
+    t.string "associated_type"
+    t.integer "user_id"
+    t.string "user_type"
+    t.string "username"
+    t.string "action"
+    t.jsonb "audited_changes"
+    t.integer "version", default: 0
+    t.string "comment"
+    t.string "remote_address"
+    t.string "request_uuid"
+    t.datetime "created_at"
+    t.index ["associated_type", "associated_id"], name: "associated_index"
+    t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
+    t.index ["created_at"], name: "index_audits_on_created_at"
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid"
+    t.index ["user_id", "user_type"], name: "user_index"
   end
 
-  create_table 'brands', force: :cascade do |t|
-    t.string('name')
-    t.boolean('canonical', default: false)
-    t.integer('count')
-    t.datetime('created_at', null: false)
-    t.datetime('updated_at', null: false)
+  create_table "brand_aliases", force: :cascade do |t|
+    t.bigint "brand_id", null: false
+    t.string "alias"
+    t.boolean "confirmed", default: false
+    t.integer "count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["brand_id"], name: "index_brand_aliases_on_brand_id"
   end
 
-  create_table 'comments', force: :cascade do |t|
-    t.text('message')
-    t.datetime('created_at', null: false)
-    t.datetime('updated_at', null: false)
+  create_table "brands", force: :cascade do |t|
+    t.string "name"
+    t.boolean "canonical", default: false
+    t.integer "count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'dictionary_entries', force: :cascade do |t|
-    t.string('phrase')
-    t.boolean('canonical', default: false)
-    t.datetime('created_at', null: false)
-    t.datetime('updated_at', null: false)
+  create_table "comments", force: :cascade do |t|
+    t.text "message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'item_measure_aliases', force: :cascade do |t|
-    t.bigint('item_measure_id', null: false)
-    t.string('alias')
-    t.boolean('confirmed', default: false)
-    t.datetime('created_at', null: false)
-    t.datetime('updated_at', null: false)
-    t.index(['item_measure_id'], name: 'index_item_measure_aliases_on_item_measure_id')
+  create_table "dictionary_entries", force: :cascade do |t|
+    t.string "phrase"
+    t.boolean "canonical", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'item_measures', force: :cascade do |t|
-    t.string('name')
-    t.boolean('canonical', default: false)
-    t.datetime('created_at', null: false)
-    t.datetime('updated_at', null: false)
+  create_table "item_measure_aliases", force: :cascade do |t|
+    t.bigint "item_measure_id", null: false
+    t.string "alias"
+    t.boolean "confirmed", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_measure_id"], name: "index_item_measure_aliases_on_item_measure_id"
   end
 
-  create_table 'item_pack_aliases', force: :cascade do |t|
-    t.bigint('item_pack_id', null: false)
-    t.string('alias')
-    t.boolean('confirmed', default: false)
-    t.datetime('created_at', null: false)
-    t.datetime('updated_at', null: false)
-    t.index(['item_pack_id'], name: 'index_item_pack_aliases_on_item_pack_id')
+  create_table "item_measures", force: :cascade do |t|
+    t.string "name"
+    t.boolean "canonical", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'item_packs', force: :cascade do |t|
-    t.string('name')
-    t.boolean('canonical', default: false)
-    t.datetime('created_at', null: false)
-    t.datetime('updated_at', null: false)
+  create_table "item_pack_aliases", force: :cascade do |t|
+    t.bigint "item_pack_id", null: false
+    t.string "alias"
+    t.boolean "confirmed", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_pack_id"], name: "index_item_pack_aliases_on_item_pack_id"
   end
 
-  create_table 'item_sell_pack_aliases', force: :cascade do |t|
-    t.bigint('item_sell_pack_id', null: false)
-    t.string('alias')
-    t.boolean('confirmed', default: false)
-    t.datetime('created_at', null: false)
-    t.datetime('updated_at', null: false)
-    t.index(['item_sell_pack_id'], name: 'index_item_sell_pack_aliases_on_item_sell_pack_id')
+  create_table "item_packs", force: :cascade do |t|
+    t.string "name"
+    t.boolean "canonical", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'item_sell_packs', force: :cascade do |t|
-    t.string('name')
-    t.boolean('canonical', default: false)
-    t.datetime('created_at', null: false)
-    t.datetime('updated_at', null: false)
+  create_table "item_sell_pack_aliases", force: :cascade do |t|
+    t.bigint "item_sell_pack_id", null: false
+    t.string "alias"
+    t.boolean "confirmed", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_sell_pack_id"], name: "index_item_sell_pack_aliases_on_item_sell_pack_id"
   end
 
-  create_table 'product_duplicates', force: :cascade do |t|
-    t.bigint('product_id', null: false)
-    t.integer('canonical_product_id')
-    t.string('action')
-    t.decimal('certainty_percentage', precision: 8, scale: 2)
-    t.integer('mapped_product_id')
-    t.decimal('levenshtein_distance', precision: 8, scale: 2)
-    t.decimal('similarity_score', precision: 8, scale: 2)
-    t.datetime('created_at', null: false)
-    t.datetime('updated_at', null: false)
-    t.index(['product_id'], name: 'index_product_duplicates_on_product_id')
+  create_table "item_sell_packs", force: :cascade do |t|
+    t.string "name"
+    t.boolean "canonical", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'products', force: :cascade do |t|
-    t.integer('product_id')
-    t.string('status')
-    t.decimal('duplication_certainty', precision: 8, scale: 2)
-    t.decimal('canonical_certainty', precision: 8, scale: 2)
-    t.string('action')
-    t.datetime('collected_statistics_at', precision: nil)
-    t.integer('spelling_mistakes')
-    t.integer('catalogue_count')
-    t.integer('buy_list_count')
-    t.integer('priced_catalogue_count')
-    t.decimal('average_price', precision: 8, scale: 2)
-    t.decimal('maximum_price', precision: 8, scale: 2)
-    t.decimal('minimum_price', precision: 8, scale: 2)
-    t.decimal('standard_deviation', precision: 8, scale: 2)
-    t.decimal('variance', precision: 8, scale: 2)
-    t.integer('inventory_barcodes_count')
-    t.integer('inventory_derived_period_balances_count')
-    t.integer('inventory_internal_requisition_lines_count')
-    t.integer('inventory_stock_counts_count')
-    t.integer('inventory_stock_levels_count')
-    t.integer('inventory_transfer_items_count')
-    t.integer('invoice_line_items_count')
-    t.integer('point_of_sale_lines_count')
-    t.integer('procurement_products_count')
-    t.integer('product_supplier_preferences_count')
-    t.integer('purchase_order_line_items_count')
-    t.integer('rebates_profile_products_count')
-    t.integer('receiving_document_line_items_count')
-    t.integer('recipes_count')
-    t.integer('requisition_line_items_count')
-    t.datetime('created_at', null: false)
-    t.datetime('updated_at', null: false)
+  create_table "product_duplicates", force: :cascade do |t|
+    t.bigint "product_id", null: false
+    t.integer "canonical_product_id"
+    t.string "action"
+    t.decimal "certainty_percentage", precision: 8, scale: 2
+    t.integer "mapped_product_id"
+    t.decimal "levenshtein_distance", precision: 8, scale: 2
+    t.decimal "similarity_score", precision: 8, scale: 2
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["product_id"], name: "index_product_duplicates_on_product_id"
   end
 
-  create_table 'tasks', force: :cascade do |t|
-    t.string('type')
-    t.integer('context_id')
-    t.string('context_type')
-    t.text('description')
-    t.jsonb('before')
-    t.jsonb('after')
-    t.string('status')
-    t.string('error')
-    t.boolean('requires_approval', default: false)
-    t.boolean('approved', default: false)
-    t.datetime('approved_at', precision: nil)
-    t.datetime('created_at', null: false)
-    t.datetime('updated_at', null: false)
+  create_table "products", force: :cascade do |t|
+    t.integer "product_id"
+    t.string "status"
+    t.decimal "duplication_certainty", precision: 8, scale: 2
+    t.decimal "canonical_certainty", precision: 8, scale: 2
+    t.string "action"
+    t.datetime "collected_statistics_at", precision: nil
+    t.integer "spelling_mistakes"
+    t.integer "catalogue_count"
+    t.integer "buy_list_count"
+    t.integer "priced_catalogue_count"
+    t.decimal "average_price", precision: 8, scale: 2
+    t.decimal "maximum_price", precision: 8, scale: 2
+    t.decimal "minimum_price", precision: 8, scale: 2
+    t.decimal "standard_deviation", precision: 8, scale: 2
+    t.decimal "variance", precision: 8, scale: 2
+    t.integer "inventory_barcodes_count"
+    t.integer "inventory_derived_period_balances_count"
+    t.integer "inventory_internal_requisition_lines_count"
+    t.integer "inventory_stock_counts_count"
+    t.integer "inventory_stock_levels_count"
+    t.integer "inventory_transfer_items_count"
+    t.integer "invoice_line_items_count"
+    t.integer "point_of_sale_lines_count"
+    t.integer "procurement_products_count"
+    t.integer "product_supplier_preferences_count"
+    t.integer "purchase_order_line_items_count"
+    t.integer "rebates_profile_products_count"
+    t.integer "receiving_document_line_items_count"
+    t.integer "recipes_count"
+    t.integer "requisition_line_items_count"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  add_foreign_key 'abbreviations', 'dictionary_entries'
-  add_foreign_key 'brand_aliases', 'brands'
-  add_foreign_key 'item_measure_aliases', 'item_measures'
-  add_foreign_key 'item_pack_aliases', 'item_packs'
-  add_foreign_key 'item_sell_pack_aliases', 'item_sell_packs'
-  add_foreign_key 'product_duplicates', 'products'
+  create_table "tasks", force: :cascade do |t|
+    t.string "type"
+    t.integer "context_id"
+    t.string "context_type"
+    t.text "description"
+    t.jsonb "before"
+    t.jsonb "after"
+    t.string "status"
+    t.string "error"
+    t.boolean "requires_approval", default: false
+    t.boolean "approved", default: false
+    t.datetime "approved_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_foreign_key "abbreviations", "dictionary_entries"
+  add_foreign_key "brand_aliases", "brands"
+  add_foreign_key "item_measure_aliases", "item_measures"
+  add_foreign_key "item_pack_aliases", "item_packs"
+  add_foreign_key "item_sell_pack_aliases", "item_sell_packs"
+  add_foreign_key "product_duplicates", "products"
 end


### PR DESCRIPTION
Changes:
* Add the `audited` gem
* Mark all records as being auditable
* Mark records that have parent/child relations as having associated audits