### PR TITLE
Date range validation, do not use params in ViewComponents

### DIFF
--- a/app/components/calendar/component.html.erb
+++ b/app/components/calendar/component.html.erb
@@ -56,7 +56,7 @@
             id="<%= "#{id}_calendar--button_#{date.strftime('%F')}" %>"
             type="button"
             class="<%= button_style(cell_date: date, index: index) %>"
-            data-action="click->calendar--component#selectDate"
+            <%= "data-action=click->calendar--component#selectDate" if selectable?(cell_date: date) %>
           >
             <!--
                Always include: "mx-auto flex h-7 w-7 items-center justify-center rounded-full"

--- a/app/components/collection_filter/date_range_component.html.erb
+++ b/app/components/collection_filter/date_range_component.html.erb
@@ -2,7 +2,7 @@
   <div class="grid grid-cols-2 gap-4" data-controller="calendar--component">
     <div>
       <label for="q_<%= attribute %>_gteq"><%= "#{attribute.to_s.humanize} is on or after" %></label>
-      <div class="mt-1 relative rounded-md" data-action="click->calendar--component#toggle" data-calendar--component-toggle-calendar-id-param="<%= attribute %>_from_calendar">
+      <div class="mt-1 w-80 relative rounded-md" data-action="click->calendar--component#toggle" data-calendar--component-toggle-calendar-id-param="<%= attribute %>_from_calendar">
         <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
@@ -12,19 +12,20 @@
           autocomplete="off"
           class="max-w-lg pl-10 block w-full shadow-lg focus:ring-sky-500 focus:border-sky-500 sm:max-w-xs sm:text-sm border-gray-300 rounded-md"
           data-action="keydown->collection-filter--component#filter select->collection-filter--component#filter"
-          value="<%= from_filter_value %>"
+          value="<%= from_date %>"
+          max="<%= to_date %>"
           type="date"
           name="q[<%= attribute %>_gteq]"
           id="q_<%= attribute %>_gteq"
         >
       </div>
       <%= turbo_frame_tag "#{attribute}_from", src: from_calendar_url, loading: :lazy do %>
-        <%= render Calendar::Component.new(id: "#{attribute}_from", year: '', month: '', input_id: "q_#{attribute}_gteq", selected_date: from_filter_value, hidden: true) %>
+        <%= render Calendar::Component.new(id: "#{attribute}_from", year: '', month: '', input_id: "q_#{attribute}_gteq", selected_date: from_date, max_date: to_date, hidden: true) %>
       <% end %>
     </div>
     <div>
       <label for="q_<%= attribute %>_lteq"><%= "#{attribute.to_s.humanize} is on or before" %></label>
-      <div class="mt-1 relative rounded-md" data-action="click->calendar--component#toggle" data-calendar--component-toggle-calendar-id-param="<%= attribute %>_to_calendar">
+      <div class="mt-1 w-80 relative rounded-md" data-action="click->calendar--component#toggle" data-calendar--component-toggle-calendar-id-param="<%= attribute %>_to_calendar">
         <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
@@ -34,14 +35,15 @@
           autocomplete="off"
           class="max-w-lg pl-10 block w-full shadow-lg focus:ring-sky-500 focus:border-sky-500 sm:max-w-xs sm:text-sm border-gray-300 rounded-md"
           data-action="keydown->collection-filter--component#filter select->collection-filter--component#filter"
-          value="<%= to_filter_value %>"
+          value="<%= to_date %>"
+          min="<%= from_date %>"
           type="date"
           name="q[<%= attribute %>_lteq]"
           id="q_<%= attribute %>_lteq"
         >
       </div>
       <%= turbo_frame_tag "#{attribute}_to", src: to_calendar_url, loading: :lazy do %>
-        <%= render Calendar::Component.new(id: "#{attribute}_to", year: '', month: '', input_id: "q_#{attribute}_lteq", selected_date: to_filter_value, hidden: true) %>
+        <%= render Calendar::Component.new(id: "#{attribute}_to", year: '', month: '', input_id: "q_#{attribute}_lteq", selected_date: to_date, min_date: from_date, hidden: true) %>
       <% end %>
     </div>
   </div>

--- a/app/components/collection_filter/date_range_component.rb
+++ b/app/components/collection_filter/date_range_component.rb
@@ -8,26 +8,26 @@ module CollectionFilter
 
     # @return [Symbol] the name of the attribute to filter on
     attr_reader :attribute
+    # @return [String] the start of the date range
+    attr_reader :from_date
+    # @return [String] the end of the date range
+    attr_reader :to_date
 
-    def initialize(attribute:)
+    def initialize(attribute:, from_date: '', to_date: '')
       super
       @attribute = attribute
+      @from_date = from_date
+      @to_date = to_date
     end
 
     def from_calendar_url
-      "/calendar?id=#{attribute}_from&input_id=q_#{attribute}_gteq&selected_date=#{from_filter_value}&hidden=true"
-    end
-
-    def from_filter_value
-      params.dig(:q, :"#{attribute}_gteq")
+      "/calendar?id=#{attribute}_from&input_id=q_#{attribute}_gteq&selected_date=#{from_date}" \
+      "&max_date=#{to_date}&hidden=true"
     end
 
     def to_calendar_url
-      "/calendar?id=#{attribute}_to&input_id=q_#{attribute}_lteq&selected_date=#{to_filter_value}&hidden=true"
-    end
-
-    def to_filter_value
-      params.dig(:q, :"#{attribute}_lteq")
+      "/calendar?id=#{attribute}_to&input_id=q_#{attribute}_lteq&selected_date=#{to_date}" \
+      "&min_date=#{from_date}&hidden=true"
     end
   end
 end

--- a/app/components/collection_filter/list_component.rb
+++ b/app/components/collection_filter/list_component.rb
@@ -8,14 +8,17 @@ module CollectionFilter
     attr_reader :attribute
     # @return [Array<Hash>] the display and value for 1 or more list options
     attr_reader :options
+    # @return [Array<String>] the currently selected options
+    attr_reader :selected_options
     # @return [Boolean] true if the options component is hidden, false otherwise
     attr_reader :hidden
 
-    def initialize(label:, attribute:, options: [], hidden: true)
+    def initialize(label:, attribute:, options: [], selected_options: [], hidden: true)
       super
       @label = label
       @attribute = attribute
       @options = options
+      @selected_options = selected_options || []
       @hidden = hidden
     end
 
@@ -23,11 +26,6 @@ module CollectionFilter
 
     def option_checked(value:)
       selected_options.include?(value)
-    end
-
-    # @todo Inject the parameters instead?
-    def selected_options
-      params.dig(:q, "#{attribute}_in") || []
     end
   end
 end

--- a/app/components/collection_filter/list_component_controller.ts
+++ b/app/components/collection_filter/list_component_controller.ts
@@ -1,5 +1,5 @@
 import {ActionEvent, Controller} from "@hotwired/stimulus"
-import cash from "cash-dom";
+import cash, {Cash} from "cash-dom";
 
 export default class extends Controller {
     static values = {
@@ -10,8 +10,10 @@ export default class extends Controller {
 
     toggle(event: ActionEvent) {
         event.preventDefault()
-        const optionsContainer: HTMLElement = cash(`#${this.attributeValue}_list--options`)[0] as HTMLElement
-        optionsContainer.toggleAttribute('hidden')
+        const optionsButton: Cash = cash(`#${this.attributeValue}_list--toggle_button`)
+        const containerEl: HTMLElement = cash(`#${this.attributeValue}_list--options`)[0] as HTMLElement
+        containerEl.toggleAttribute('hidden')
+        optionsButton.toggleClass('-rotate-180 rotate-0')
     }
 
     selectOption(event: ActionEvent) {

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -9,6 +9,8 @@ class CalendarController < ApplicationController
   # @param [Integer] month the calendar month to display
   # @param [String] input_id the HTML id of the input that should receive calendar selection updates
   # @param [String] selected_date the date that is currently selected in YYYY-MM-DD format
+  # @param [String] max_date the maximum date that can be selected
+  # @param [String] min_date the minimum date that can be selected
   # @param [Boolean] hidden true to add the hidden attribute to the calendar container
   # @example Calendar for Year 2022, Month July
   #    /calendar?id=created_at_from&input_id=q_created_at_gteq&year=2022&month=7

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -23,11 +23,16 @@
                  { text: 'Create', value: 'create' },
                  { text: 'Update', value: 'update' },
                  { text: 'Destroy', value: 'destroy' },
-             ]
+             ],
+             selected_options: params.dig(:q, "action_in")
          ) %>
     <% end %>
     <% component.with_element do |e| %>
-      <% e.with_component_date_range(attribute: :created_at) %>
+      <% e.with_component_date_range(
+             attribute: :created_at,
+             from_date: params.dig(:q, :created_at_gteq),
+             to_date: params.dig(:q, :created_at_lteq)
+         ) %>
     <% end %>
   <% end %>
 

--- a/app/views/calendar/index.html+turbo_frame.erb
+++ b/app/views/calendar/index.html+turbo_frame.erb
@@ -4,4 +4,6 @@
     month: params[:month],
     input_id: params[:input_id],
     selected_date: params[:selected_date],
+    max_date: params[:max_date],
+    min_date: params[:min_date],
     hidden: ActiveModel::Type::Boolean.new.cast(params[:hidden])) %>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -10,7 +10,8 @@ module.exports = {
   safelist: [
     {
       pattern: /(bg|text)-(amber|emerald|sky|rose)-(50|100|200|300|400|500|600|700|800|900)/
-    }
+    },
+    'cursor-not-allowed'
   ],
   theme: {
     extend: {

--- a/test/components/calendar_component_test.rb
+++ b/test/components/calendar_component_test.rb
@@ -15,9 +15,15 @@ class Calendar::ComponentTest < ViewComponent::TestCase
         )
       )
 
-      assert_selector('a#created_at_from_calendar--previous_month_button[href="/calendar?id=created_at_from&input_id=the_input_id&year=2022&month=7"]')
+      assert_selector(
+        'a#created_at_from_calendar--previous_month_button[href="/calendar?id=created_at_from' \
+        '&input_id=the_input_id&year=2022&month=7&max_date=&min_date="]'
+      )
       assert_selector('#created_at_from_calendar--current_year_month', text: 'August 2022')
-      assert_selector('a#created_at_from_calendar--next_month_button[href="/calendar?id=created_at_from&input_id=the_input_id&year=2022&month=9"]')
+      assert_selector(
+        'a#created_at_from_calendar--next_month_button[href="/calendar?id=created_at_from' \
+        '&input_id=the_input_id&year=2022&month=9&max_date=&min_date="]'
+      )
     end
   end
 
@@ -53,6 +59,56 @@ class Calendar::ComponentTest < ViewComponent::TestCase
 
       assert_selector('button#created_at_from_calendar--button_2023-08-04.text-white.font-semibold')
       assert_selector('time#created_at_from_calendar--time_2023-08-04.bg-gray-900')
+    end
+  end
+
+  test 'when there is a minimum valid date' do
+    travel_to(Time.zone.local(2022, 8, 28)) do
+      render_inline(
+        Calendar::Component.new(
+          id: :created_at_from,
+          year: '2022',
+          month: '8',
+          input_id: :the_input_id,
+          min_date: '2022-08-25',
+          hidden: false
+        )
+      )
+
+      assert_selector(
+        'a#created_at_from_calendar--previous_month_button[href="/calendar?id=created_at_from' \
+        '&input_id=the_input_id&year=2022&month=7&max_date=&min_date=2022-08-25"]'
+      )
+      assert_selector('#created_at_from_calendar--current_year_month', text: 'August 2022')
+      assert_selector(
+        'a#created_at_from_calendar--next_month_button[href="/calendar?id=created_at_from' \
+        '&input_id=the_input_id&year=2022&month=9&max_date=&min_date=2022-08-25"]'
+      )
+    end
+  end
+
+  test 'when there is a maximum valid date' do
+    travel_to(Time.zone.local(2022, 8, 28)) do
+      render_inline(
+        Calendar::Component.new(
+          id: :created_at_from,
+          year: '2022',
+          month: '8',
+          input_id: :the_input_id,
+          max_date: '2022-08-25',
+          hidden: false
+        )
+      )
+
+      assert_selector(
+        'a#created_at_from_calendar--previous_month_button[href="/calendar?id=created_at_from' \
+        '&input_id=the_input_id&year=2022&month=7&max_date=2022-08-25&min_date="]'
+      )
+      assert_selector('#created_at_from_calendar--current_year_month', text: 'August 2022')
+      assert_selector(
+        'a#created_at_from_calendar--next_month_button[href="/calendar?id=created_at_from' \
+        '&input_id=the_input_id&year=2022&month=9&max_date=2022-08-25&min_date="]'
+      )
     end
   end
 end

--- a/test/components/date_range_component_test.rb
+++ b/test/components/date_range_component_test.rb
@@ -11,4 +11,36 @@ class CollectionFilter::DateRangeComponentTest < ViewComponent::TestCase
     assert_selector('label[for="q_created_at_lteq"]', text: 'Created at is on or before')
     assert_selector('input#q_created_at_lteq[name="q[created_at_lteq]"]')
   end
+
+  test 'when there is a to date set' do
+    travel_to(Time.zone.local(2022, 8, 5)) do
+      render_inline(CollectionFilter::DateRangeComponent.new(attribute: :created_at, to_date: '2022-08-10'))
+
+      assert_selector('#q_created_at_gteq[max="2022-08-10"]')
+      assert_selector(
+        'button#created_at_from_calendar--button_2022-08-10[data-action="click->calendar--component#selectDate"]',
+        visible: false
+      )
+      assert_no_selector(
+        'button#created_at_from_calendar--button_2022-08-11[data-action="click->calendar--component#selectDate"]',
+        visible: false
+      )
+    end
+  end
+
+  test 'when there is a from date set' do
+    travel_to(Time.zone.local(2022, 8, 5)) do
+      render_inline(CollectionFilter::DateRangeComponent.new(attribute: :created_at, from_date: '2022-08-11'))
+
+      assert_selector('#q_created_at_lteq[min="2022-08-11"]')
+      assert_no_selector(
+        'button#created_at_to_calendar--button_2022-08-10[data-action="click->calendar--component#selectDate"]',
+        visible: false
+      )
+      assert_selector(
+        'button#created_at_to_calendar--button_2022-08-11[data-action="click->calendar--component#selectDate"]',
+        visible: false
+      )
+    end
+  end
 end

--- a/test/components/stories/calendar/component_stories.rb
+++ b/test/components/stories/calendar/component_stories.rb
@@ -5,5 +5,13 @@ module Calendar
     story :basic do
       constructor(id: 'a_date', year: text('2022'), month: text('8'), input_id: 'an_input', hidden: false)
     end
+
+    story :max_date do
+      constructor(id: 'a_date', year: text('2022'), month: text('8'), input_id: 'an_input', max_date: text('2022-08-20'), hidden: false)
+    end
+
+    story :min_date do
+      constructor(id: 'a_date', year: text('2022'), month: text('8'), input_id: 'an_input', min_date: text('2022-08-20'), hidden: false)
+    end
   end
 end

--- a/test/system/audits_test.rb
+++ b/test/system/audits_test.rb
@@ -16,10 +16,20 @@ class AuditsTest < ApplicationSystemTestCase
     login
     visit item_sell_pack_audits_url(item_sell_pack_id: @item_sell_pack)
     assert_selector 'h1', text: 'Audits'
+    assert_selector('#action_list--label', text: 'Actions')
+    assert_selector('#action_list--count', text: '0')
     assert_selector('label[for="q_created_at_gteq"]', text: 'Created at is on or after')
     assert_selector('input#q_created_at_gteq[name="q[created_at_gteq]"]')
     assert_selector('label[for="q_created_at_lteq"]', text: 'Created at is on or before')
     assert_selector('input#q_created_at_lteq[name="q[created_at_lteq]"]')
+
+    find('#action_list--label').click
+    assert_selector('input#action_list--option_0[name="q[action_in][]"][value="create"]', visible: true)
+    assert_selector('label[for="action_list--option_0"]', text: 'Create', visible: true)
+    assert_selector('input#action_list--option_1[name="q[action_in][]"][value="update"]', visible: true)
+    assert_selector('label[for="action_list--option_1"]', text: 'Update', visible: true)
+    assert_selector('input#action_list--option_2[name="q[action_in][]"][value="destroy"]', visible: true)
+    assert_selector('label[for="action_list--option_2"]', text: 'Destroy', visible: true)
   end
 
   test 'index page tabs' do


### PR DESCRIPTION
Changes:
* Calendar component will now enforce a min or max date selection if one is given
* Remove use of params in ViewComponents