### PR TITLE
Part 29 - N+1s and indexes for performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,14 @@ group :development, :test do
   gem 'deepl-rb'
   gem 'easy_translate'
   gem 'i18n-tasks', '~> 1.0.11'
+
+  # N+1 query locator
+  gem 'pg_query'
+  gem 'prosopite'
+
+  # Missing index locator
+  gem 'lol_dba'
+
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,9 @@ GEM
     foreman (0.87.2)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    google-protobuf (3.21.7)
+    google-protobuf (3.21.7-x86_64-darwin)
+    google-protobuf (3.21.7-x86_64-linux)
     hashie (5.0.0)
     highline (2.0.3)
     html_tokenizer (0.0.7)
@@ -151,6 +154,10 @@ GEM
     jwt (2.4.1)
     launchy (2.5.0)
       addressable (~> 2.7)
+    lol_dba (2.4.0)
+      actionpack
+      activerecord
+      railties
     loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -214,6 +221,9 @@ GEM
     parser (3.1.2.0)
       ast (~> 2.4.1)
     pg (1.4.1)
+    pg_query (2.1.4)
+      google-protobuf (>= 3.19.2)
+    prosopite (1.1.3)
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -385,11 +395,14 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails (~> 1.0)
   launchy
+  lol_dba
   omniauth
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   pagy
   pg (~> 1.1)
+  pg_query
+  prosopite
   puma (~> 5.0)
   rack-cors
   rails (~> 7.0.3, >= 7.0.3.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,17 @@ class ApplicationController < ActionController::Base
 
   add_flash_types :success, :information, :error, :warning
 
+  unless Rails.env.production?
+    around_action :n_plus_one_detection
+
+    def n_plus_one_detection
+      Prosopite.scan
+      yield
+    ensure
+      Prosopite.finish
+    end
+  end
+
   protected
 
   def current_user

--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -3,6 +3,10 @@
 class BrandsController < ResourcesController
   private
 
+  def collection_preloads
+    [:brand_aliases]
+  end
+
   # Only allow a list of trusted parameters through.
   def permitted_params
     super | %i[name canonical count]

--- a/app/controllers/concerns/resources.rb
+++ b/app/controllers/concerns/resources.rb
@@ -28,7 +28,7 @@ module Resources
   end
 
   def set_resource
-    @resource = resource_class.find(params[:id])
+    @resource = resource_class.preload(collection_preloads).find(params[:id])
     @resource.form_authenticity_token = form_authenticity_token
   end
 

--- a/app/controllers/dictionary_entries_controller.rb
+++ b/app/controllers/dictionary_entries_controller.rb
@@ -3,6 +3,10 @@
 class DictionaryEntriesController < ResourcesController
   private
 
+  def collection_preloads
+    [:abbreviations]
+  end
+
   # Only allow a list of trusted parameters through.
   def permitted_params
     super | %i[phrase canonical]

--- a/app/controllers/item_measures_controller.rb
+++ b/app/controllers/item_measures_controller.rb
@@ -3,6 +3,10 @@
 class ItemMeasuresController < ResourcesController
   private
 
+  def collection_preloads
+    [:item_measure_aliases]
+  end
+
   # Only allow a list of trusted parameters through.
   def permitted_params
     super | %i[name canonical]

--- a/app/controllers/item_packs_controller.rb
+++ b/app/controllers/item_packs_controller.rb
@@ -3,6 +3,10 @@
 class ItemPacksController < ResourcesController
   private
 
+  def collection_preloads
+    [:item_pack_aliases]
+  end
+
   # Only allow a list of trusted parameters through.
   def permitted_params
     super | %i[name canonical]

--- a/app/controllers/item_sell_pack_aliases_controller.rb
+++ b/app/controllers/item_sell_pack_aliases_controller.rb
@@ -40,8 +40,12 @@ class ItemSellPackAliasesController < ResourcesController
   end
 
   def parent
-    @parent ||=
-      parent_class
-      .find_by(id: params[:item_sell_pack_id] || params.dig(:item_sell_pack_alias, :item_sell_pack_id))
+    return nil unless parent_id
+
+    @parent ||= parent_class.find_by(id: parent_id)
+  end
+
+  def parent_id
+    params[:item_sell_pack_id] || params.dig(:item_sell_pack_alias, :item_sell_pack_id)
   end
 end

--- a/app/controllers/item_sell_packs_controller.rb
+++ b/app/controllers/item_sell_packs_controller.rb
@@ -5,6 +5,10 @@ class ItemSellPacksController < ResourcesController
 
   private
 
+  def collection_preloads
+    [:item_sell_pack_aliases]
+  end
+
   # Only allow a list of trusted parameters through.
   def permitted_params
     super | %i[name canonical]

--- a/app/controllers/product_translations_controller.rb
+++ b/app/controllers/product_translations_controller.rb
@@ -36,8 +36,12 @@ class ProductTranslationsController < ResourcesController
   end
 
   def parent
-    @parent ||=
-      parent_class
-      .find_by(id: params[:product_id] || params.dig(:product_translation, :product_id))
+    return unless parent_id
+
+    @parent ||= parent_class.find_by(id: parent_id)
+  end
+
+  def parent_id
+    params[:product_id] || params.dig(:product_translation, :product_id)
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -5,6 +5,10 @@ class ProductsController < ResourcesController
 
   private
 
+  def collection_preloads
+    [:product_translations, :product_duplicates]
+  end
+
   # Only allow a list of trusted parameters through.
   def permitted_params
     super | %i[item_description brand item_size item_measure item_pack_name item_sell_quantity item_sell_pack_name]

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Brand < ApplicationRecord
-  has_many :brand_aliases, dependent: :destroy
+  has_many :brand_aliases, dependent: :destroy, strict_loading: true
   has_associated_audits
 
   audited

--- a/app/models/dictionary_entry.rb
+++ b/app/models/dictionary_entry.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class DictionaryEntry < ApplicationRecord
-  has_many :abbreviations, dependent: :destroy
+  has_many :abbreviations, dependent: :destroy, strict_loading: true
   has_associated_audits
 
   audited

--- a/app/models/item_measure.rb
+++ b/app/models/item_measure.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ItemMeasure < ApplicationRecord
-  has_many :item_measure_aliases, dependent: :destroy
+  has_many :item_measure_aliases, dependent: :destroy, strict_loading: true
   has_associated_audits
 
   audited

--- a/app/models/item_sell_pack.rb
+++ b/app/models/item_sell_pack.rb
@@ -3,7 +3,7 @@
 class ItemSellPack < ApplicationRecord
   include Broadcast
 
-  has_many :item_sell_pack_aliases, dependent: :destroy
+  has_many :item_sell_pack_aliases, dependent: :destroy, strict_loading: true
   has_associated_audits
 
   audited

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -4,8 +4,8 @@ class Product < ApplicationRecord
   include Broadcast
 
   belongs_to :external_product, class_name: 'External::Product', foreign_key: :product_id, inverse_of: :product
-  has_many :product_duplicates, dependent: :destroy
-  has_many :product_translations, dependent: :destroy
+  has_many :product_duplicates, dependent: :destroy, strict_loading: true
+  has_many :product_translations, dependent: :destroy, strict_loading: true
 
   has_associated_audits
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,6 +73,11 @@ Rails.application.configure do
   config.action_controller.asset_host = 'http://localhost:3000'
 
   config.view_component.instrumentation_enabled = true
+
+  config.after_initialize do
+    Prosopite.rails_logger = true
+    Prosopite.prosopite_logger = true
+  end
 end
 
 ActiveSupport::Notifications.subscribe('!render.view_component') do |*args|

--- a/db/migrate/20221010131051_add_index_for_filters.rb
+++ b/db/migrate/20221010131051_add_index_for_filters.rb
@@ -1,0 +1,21 @@
+class AddIndexForFilters < ActiveRecord::Migration[7.0]
+  def up
+    execute <<-SQL
+      CREATE EXTENSION pg_trgm;
+      CREATE INDEX index_products_item_description_gin ON products USING gin (item_description gin_trgm_ops);
+    SQL
+    add_index :item_sell_packs, :canonical
+    add_index :item_sell_pack_aliases, :confirmed
+    add_index :audits, :action
+  end
+
+  def down
+    remove_index :index_products_item_description_gin
+    remove_index :item_sell_packs, :canonical
+    remove_index :item_sell_pack_aliases, :confirmed
+    remove_index :audits, :action
+    execute <<-SQL
+      DROP EXTENSION pg_trgm;
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_04_163702) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_10_131051) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
   # Custom types defined in this database.
@@ -44,6 +45,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_04_163702) do
     t.string "remote_address"
     t.string "request_uuid"
     t.datetime "created_at"
+    t.index ["action"], name: "index_audits_on_action"
     t.index ["associated_type", "associated_id"], name: "associated_index"
     t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
     t.index ["created_at"], name: "index_audits_on_created_at"
@@ -128,6 +130,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_04_163702) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["alias"], name: "index_item_sell_pack_aliases_on_alias", unique: true
+    t.index ["confirmed"], name: "index_item_sell_pack_aliases_on_confirmed"
     t.index ["item_sell_pack_id"], name: "index_item_sell_pack_aliases_on_item_sell_pack_id"
   end
 
@@ -136,6 +139,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_04_163702) do
     t.boolean "canonical", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["canonical"], name: "index_item_sell_packs_on_canonical"
     t.index ["name"], name: "index_item_sell_packs_on_name", unique: true
   end
 
@@ -231,6 +235,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_04_163702) do
     t.integer "issues_count", default: 0, null: false
     t.integer "translations_count", default: 0, null: false
     t.index ["category_id"], name: "index_products_on_category_id"
+    t.index ["item_description"], name: "index_products_item_description_gin", opclass: :gin_trgm_ops, using: :gin
+    t.index ["item_sell_pack_name"], name: "idx_products_item_sell_pack_name"
     t.index ["product_id"], name: "index_products_on_product_id", unique: true
     t.check_constraint "average_price >= 0::numeric", name: "average_price_check"
     t.check_constraint "buy_list_count >= 0", name: "buy_list_count_check"

--- a/test/controllers/item_sell_pack_aliases_controller_test.rb
+++ b/test/controllers/item_sell_pack_aliases_controller_test.rb
@@ -107,7 +107,7 @@ class ItemSellPackAliasesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'raises error for HTML' do
-    ItemSellPackAlias.stub(:find, -> (_id) { raise(StandardError) }) do
+    ItemSellPackAlias.stub(:preload, -> (_id) { raise(StandardError) }) do
       authenticate
 
       assert_raises(StandardError) do

--- a/test/controllers/item_sell_packs_controller_test.rb
+++ b/test/controllers/item_sell_packs_controller_test.rb
@@ -103,7 +103,7 @@ class ItemSellPacksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'raises error for HTML' do
-    ItemSellPack.stub(:find, -> (_id) { raise(StandardError) }) do
+    ItemSellPack.stub(:preload, -> (_) { raise(StandardError) }) do
       authenticate
 
       assert_raises(StandardError) do


### PR DESCRIPTION
Changes:
* Add `prosopite` gem to warn of N+1s
* Add `lol_dba` gem to find any missing indexes for relationships
* Use `strict_loading` on model associations and update controllers to preload the associations
* Add indexes for the attributes being filtered on so far