### PR TITLE
Add a tree selection component for forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 # README
 
+####Philosophy:
+* Products are taken from the PurchasePlus goods_products table and exist as a "shadow" version of those products.
+* The shadow products are examined for issues, such as extra whitespace, missing or incorrect attributes, or whether the product is considered a duplicate.
+* These issues can spawn self-repairing tasks if a known solution is available.
+* Otherwise a human user can edit the products manually to resolve other types of issues where the system cannot determine the correct solution alone.
+
 ####Requirements:
 * Ruby 3.0.4
 * Bundler
@@ -28,6 +34,7 @@
 
 ####Running Storybook:
 
+`export NODE_OPTIONS=--openssl-legacy-provider`
 `yarn storybook`
 
 ####After adding/deleting Stimulus controllers:

--- a/app/components/index.js
+++ b/app/components/index.js
@@ -26,3 +26,6 @@ application.register("resource-form--component", ResourceForm__ComponentControll
 
 import ResourceForm__DropdownComponentController from "./resource_form/dropdown_component_controller"
 application.register("resource-form--dropdown-component", ResourceForm__DropdownComponentController)
+
+import ResourceForm__TreeSelectComponentController from "./resource_form/tree_select_component_controller"
+application.register("resource-form--tree-select-component", ResourceForm__TreeSelectComponentController)

--- a/app/components/resource_form/dropdown_component.html.erb
+++ b/app/components/resource_form/dropdown_component.html.erb
@@ -21,14 +21,14 @@
            data-resource-form--dropdown-component-input-id-value="<%= field_id %>--input"
            data-resource-form--component-field-id-param="<%= field_id %>"
       >
-        <div class="relative mt-1">
+        <div class="relative mt-1 w-full max-w-2xl">
           <input
             id="<%= field_id %>--input"
             value="<%= selected_text %>"
             data-action="keydown->editor#cancel"
             autofocus
             type="text"
-            class="w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-12 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 sm:text-sm"
+            class="w-full max-w-2xl rounded-md border border-gray-300 bg-white py-2 pl-3 pr-12 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 sm:text-sm"
             role="combobox" aria-controls="options" aria-expanded="false" autocomplete="off"
             data-editor-url-param="<%= polymorphic_path(resource) %>"
             data-editor-field-id-param="<%= field_id %>--hidden-input"

--- a/app/components/resource_form/field_component.rb
+++ b/app/components/resource_form/field_component.rb
@@ -13,7 +13,8 @@ module ResourceForm
       image: ResourceForm::ImageComponent,
       dropdown: ResourceForm::DropdownComponent,
       country_dropdown: ResourceForm::CountryDropdownComponent,
-      locale_dropdown: ResourceForm::LocaleDropdownComponent
+      locale_dropdown: ResourceForm::LocaleDropdownComponent,
+      tree_select: ResourceForm::TreeSelectComponent
     }
   end
 end

--- a/app/components/resource_form/number_component.html.erb
+++ b/app/components/resource_form/number_component.html.erb
@@ -15,7 +15,7 @@
     <% else %>
     <turbo-frame id="<%= dom_id(resource, "#{attribute}_turbo_frame") %>" class="contents">
       <input
-        class="peer block max-w-lg w-full shadow-sm focus:ring-sky-500 focus:border-sky-500 sm:text-sm border-gray-300 rounded-md"
+        class="peer block max-w-2xl w-full shadow-sm focus:ring-sky-500 focus:border-sky-500 sm:text-sm border-gray-300 rounded-md"
         autofocus="autofocus"
         type="number"
         <%= 'required' if required? %>

--- a/app/components/resource_form/text_component.html.erb
+++ b/app/components/resource_form/text_component.html.erb
@@ -21,7 +21,7 @@
     <% else %>
     <turbo-frame id="<%= dom_id(resource, "#{attribute}_turbo_frame") %>" class="contents">
       <input
-        class="peer block max-w-lg w-full shadow-sm focus:ring-sky-500 focus:border-sky-500 sm:text-sm border-gray-300 rounded-md"
+        class="peer block max-w-2xl w-full shadow-sm focus:ring-sky-500 focus:border-sky-500 sm:text-sm border-gray-300 rounded-md"
         autofocus="autofocus"
         type="text"
         <%= 'required' if required? %>

--- a/app/components/resource_form/tree_select_component.html.erb
+++ b/app/components/resource_form/tree_select_component.html.erb
@@ -1,0 +1,121 @@
+<div class="sm:grid sm:grid-cols-3 sm:gap-4 sm:items-start sm:border-t sm:border-gray-200 sm:pt-5" data-controller="resource-form--component">
+  <div>
+    <label id="<%= field_id %>--label" for="<%= field_id %>" class="block text-sm font-medium text-gray-700 sm:mt-px sm:pt-">
+      <%= label %>
+    </label>
+    <% if help.present? %>
+      <div id="<%= field_id %>--help" class="mt-2 text-sm text-gray-300 inline-flex items-center">
+        <%= icon(name: :question_mark_circle, colour: :blue, options: { size: 5 }) %><%= help %>
+      </div>
+    <% end %>
+  </div>
+  <div class="mt-1 sm:mt-0 sm:col-span-2">
+    <turbo-frame id="<%= dom_id(resource, "#{attribute}_turbo_frame") %>" class="contents">
+      <% if display_only? %>
+        <p id="<%= field_id %>" class="mt-2 text-sm text-gray-500"><%= selected_text %></p>
+      <% else %>
+        <div class="w-full max-w-2xl"
+             data-controller="resource-form--tree-select-component"
+             data-resource-form--tree-select-component-tree-list-id-value="<%= field_id %>--tree-list"
+             data-resource-form--tree-select-component-hidden-input-id-value="<%= field_id %>--hidden-input"
+             data-resource-form--tree-select-component-input-id-value="<%= field_id %>--input"
+             data-resource-form--component-field-id-param="<%= field_id %>"
+        >
+          <div class="relative mt-1 w-full">
+            <input
+              id="<%= field_id %>--input"
+              value="<%= selected_text %>"
+              data-action="keydown->editor#cancel"
+              autofocus
+              type="text"
+              class="w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-12 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 sm:text-sm"
+              role="combobox" aria-controls="options" aria-expanded="false" autocomplete="off"
+              data-editor-url-param="<%= polymorphic_path(resource) %>"
+              data-editor-field-id-param="<%= field_id %>--hidden-input"
+              data-editor-attribute-param="<%= attribute %>"
+              data-editor-resource-name-param="<%= resource.resource_name %>"
+            >
+            <input
+              id="<%= field_id %>--hidden-input"
+              value="<%= selected_value %>"
+              type="hidden"
+              name="<%= field_name %>"
+              data-action="change->editor#select"
+              data-editor-url-param="<%= polymorphic_path(resource) %>"
+              data-editor-field-id-param="<%= field_id %>--hidden-input"
+              data-editor-attribute-param="<%= attribute %>"
+            >
+            <% unless display_only? %>
+              <button
+                id="<%= field_id %>--button"
+                type="button"
+                class="absolute inset-y-0 right-0 flex items-center rounded-r-md px-2 focus:outline-none"
+                data-action="click->resource-form--tree-select-component#toggle keydown->editor#cancel"
+                data-editor-url-param="<%= polymorphic_path(resource) %>"
+                data-editor-field-id-param="<%= field_id %>--hidden-input"
+                data-editor-attribute-param="<%= attribute %>"
+                data-editor-resource-name-param="<%= resource.resource_name %>"
+              >
+                <!-- Heroicon name: mini/chevron-up-down -->
+                <svg class="h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path fill-rule="evenodd" d="M10 3a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L10 4.852 7.3 7.76a.75.75 0 01-1.1-1.02l3.25-3.5A.75.75 0 0110 3zm-3.76 9.2a.75.75 0 011.06.04l2.7 2.908 2.7-2.908a.75.75 0 111.1 1.02l-3.25 3.5a.75.75 0 01-1.1 0l-3.25-3.5a.75.75 0 01.04-1.06z" clip-rule="evenodd" />
+                </svg>
+              </button>
+            <% end %>
+
+            <ul id="<%= field_id %>--tree-list" <%= 'hidden' if hidden %> class="w-full flex-grow absolute z-10 mt-1 max-h-56 overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm" id="options" role="listbox">
+              <% roots.each_with_index do |root, root_index| %>
+                <li
+                  id="<%= field_id %>--root-<%= root_index %>"
+                  class="pl-2 pr-2 py-2 font-medium rounded-md hover:bg-sky-700 hover:text-white flex"
+                  data-resource-form--tree-select-component-children-id-param="<%= field_id %>--root-<%= root_index %>__children"
+                  data-resource-form--tree-select-component-expander-id-param="<%= field_id %>--root-<%= root_index %>__expander"
+                  data-action="click->resource-form--tree-select-component#toggleRoot"
+                >
+                  <div><%= root.to_s %></div>
+                  <div class="relative">
+                    <svg id="<%= field_id %>--root-<%= root_index %>__expander" class="text-gray-300 ml-3 flex-shrink-0 h-5 w-5 transform group-hover:text-gray-400 transition-colors ease-in-out duration-150" viewBox="0 0 20 20" aria-hidden="true">
+                      <path d="M6 6L14 10L6 14V6Z" fill="currentColor" />
+                    </svg>
+                  </div>
+                </li>
+                <ul id="<%= field_id %>--root-<%= root_index %>__children" class="hidden flex pl-2">
+                  <div class="bg-sky-200 w-1"></div>
+                  <div>
+                    <% root.children.each_with_index do |child, child_index| %>
+                      <li
+                        class="relative pl-7 pr-9 py-1 rounded-md hover:bg-sky-700 hover:text-white"
+                        id="<%= field_id %>--child-<%= child_index %>"
+                        data-resource-form--tree-select-component-child-value-param="<%= child.id %>"
+                        data-resource-form--tree-select-component-child-text-param="<%= child.name %>"
+                        data-resource-form--tree-select-component-checkmark-id-param="<%= field_id %>--<%= child.id %>-checkmark"
+                        data-action="click->resource-form--tree-select-component#select"
+                        role="option"
+                        tabindex="-1"
+                      >
+                        <div class="flex items-center">
+                          <span class="truncate <%= 'font-semibold' if selected?(value: child.id) %>" title="<%= child.name %>">
+                            <%= child.to_s %>
+                          </span>
+                          <span
+                            id="<%= field_id %>--<%= child.id %>-checkmark"
+                            data-resource-form--tree-select-component-target="checkmark"
+                            class="<%= 'hidden' unless selected?(value: child.id) %> absolute inset-y-0 right-0 flex items-center pr-4 text-sky-600">
+                            <!-- Heroicon name: mini/check -->
+                            <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                              <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd" />
+                            </svg>
+                          </span>
+                        </div>
+                      </li>
+                    <% end %>
+                  </div>
+                </ul>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      <% end %>
+    </turbo-frame>
+  </div>
+</div>

--- a/app/components/resource_form/tree_select_component.rb
+++ b/app/components/resource_form/tree_select_component.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module ResourceForm
+  class TreeSelectComponent < BaseComponent
+    # @return [Array] the roots of the tree
+    attr_reader :roots
+    # @return [Class] the class that implements a roots method
+    attr_reader :root_class
+    # @return [String] the currently selected value
+    attr_reader :selected_value
+    # @return [Boolean] true if the items list is hidden, false otherwise
+    attr_reader :hidden
+
+    def initialize(attribute:, label:, resource:, root_class:, hidden: true, options: {})
+      super(attribute: attribute, label: label, resource: resource, options: options)
+      @root_class = root_class
+      @roots = root_class.roots
+      @selected_value = resource.send(attribute)
+      @hidden = hidden
+    end
+
+    private
+
+    def selected?(value:)
+      selected_value == value
+    end
+
+    def selected_text
+      selected_item&.to_s
+    end
+
+    def selected_item
+      root_class.find_by(id: selected_value)
+    end
+  end
+end

--- a/app/components/resource_form/tree_select_component_controller.ts
+++ b/app/components/resource_form/tree_select_component_controller.ts
@@ -1,0 +1,77 @@
+import {ActionEvent, Controller} from "@hotwired/stimulus"
+import cash, { Cash } from "cash-dom"
+
+export default class extends Controller {
+    static values = {
+        inputId: String,
+        hiddenInputId: String,
+        treeListId: String
+    }
+    static targets = ["checkmark"]
+
+    declare readonly inputIdValue: string;
+    declare readonly hiddenInputIdValue: string;
+    declare readonly treeListIdValue: string;
+    declare readonly checkmarkTarget: HTMLElement;
+    declare readonly checkmarkTargets: HTMLElement[];
+
+    // Toggle visibility of the tree list
+    toggle(event: ActionEvent) {
+        event.preventDefault()
+        const treeSelectEl: HTMLElement = cash(`#${this.treeListIdValue}`)[0] as HTMLElement
+        const inputEl: HTMLInputElement | null = document.querySelector(`#${this.inputIdValue}`)
+        treeSelectEl.toggleAttribute('hidden')
+        if (inputEl) {
+            inputEl.dispatchEvent(new Event('focus'))
+        }
+    }
+
+    // Toggle visibility of a root's children
+    toggleRoot(event: ActionEvent) {
+        event.preventDefault()
+        const childrenEl: Cash = cash(`#${event.params.childrenId}`)
+        const expanderEl: HTMLElement = cash(`#${event.params.expanderId}`)[0] as HTMLElement
+        childrenEl.toggleClass('hidden')
+        this.toggleExpander(expanderEl)
+    }
+
+    toggleExpander(expanderEl: HTMLElement) {
+        // Rotate the triangle icon representing whether the expander is open or not
+        if (expanderEl.classList.contains("text-gray-300")) {
+            expanderEl.classList.remove("text-gray-300");
+            expanderEl.classList.add("text-gray-400", "rotate-90");
+        } else {
+            expanderEl.classList.remove("text-gray-400", "rotate-90");
+            expanderEl.classList.add("text-gray-300");
+        }
+    }
+
+    // Set the value of the associated inputs to the item a user has selected
+    select(event: ActionEvent) {
+        const checkmarkEl: HTMLElement | null = document.querySelector(`#${event.params.checkmarkId}`)
+        const inputEl: HTMLInputElement | null = document.querySelector(`#${this.inputIdValue}`)
+        const hiddenInputEl: HTMLInputElement | null = document.querySelector(`#${this.hiddenInputIdValue}`)
+        const value: string = event.params.childValue
+        const text: string = event.params.childText
+
+        if (inputEl && hiddenInputEl) {
+            // Set the input values
+            inputEl.value = text
+            hiddenInputEl.value = value
+            hiddenInputEl.dispatchEvent(new Event('change'))
+
+            // Deselect any currently selected item
+            this.checkmarkTargets.forEach(function (checkmark) {
+                checkmark.classList.add('hidden')
+            })
+
+            // Select this item
+            if (checkmarkEl) {
+                checkmarkEl.classList.remove('hidden')
+            }
+
+            // Hide the tree select
+            this.toggle(event)
+        }
+    }
+}

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -16,7 +16,9 @@ class ProductsController < ResourcesController
 
   # Only allow a list of trusted parameters through.
   def permitted_params
-    super | %i[item_description brand item_size item_measure item_pack_name item_sell_quantity item_sell_pack_name]
+    super | %i[
+      item_description brand item_size item_measure item_pack_name item_sell_quantity item_sell_pack_name category_id
+    ]
   end
 
   def default_sort

--- a/app/models/external/category.rb
+++ b/app/models/external/category.rb
@@ -4,5 +4,19 @@ module External
   # Connects to external Goods::Category class
   class Category < External::ApplicationRecord
     self.table_name = :goods_categories
+
+    belongs_to :parent, class_name: 'External::Category'
+    has_many :children,
+             -> { order(:name) },
+             class_name: 'External::Category',
+             foreign_key: :parent_id,
+             dependent: nil,
+             inverse_of: :parent
+
+    scope :roots, -> { where(parent_id: nil).order(:name) }
+
+    def to_s
+      name
+    end
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -6,6 +6,7 @@ class Product < ApplicationRecord
   include Importable
 
   belongs_to :external_product, class_name: 'External::Product', inverse_of: :product
+  belongs_to :category, class_name: 'External::Category'
   has_many :product_duplicates, dependent: :destroy, strict_loading: true
   has_many :product_translations, dependent: :destroy, strict_loading: true
   has_many :product_issues, dependent: :destroy, strict_loading: true

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -6,7 +6,7 @@ class Product < ApplicationRecord
   include Importable
 
   belongs_to :external_product, class_name: 'External::Product', inverse_of: :product
-  belongs_to :category, class_name: 'External::Category'
+  belongs_to :category, class_name: 'External::Category', optional: true
   has_many :product_duplicates, dependent: :destroy, strict_loading: true
   has_many :product_translations, dependent: :destroy, strict_loading: true
   has_many :product_issues, dependent: :destroy, strict_loading: true

--- a/app/views/products/_resource.html.erb
+++ b/app/views/products/_resource.html.erb
@@ -71,6 +71,15 @@
          ) %>
     <% end %>
     <% component.with_field do |c| %>
+      <% c.with_attribute_tree_select(
+             attribute: :category_id,
+             label: resource_class.human_attribute_name(:category),
+             resource: resource,
+             root_class: External::Category,
+             options: { readonly: readonly, required: true, invalid_message: t('.invalid_message.category') }
+         ) %>
+    <% end %>
+    <% component.with_field do |c| %>
       <% c.with_attribute_timestamp(attribute: :created_at, label: resource_class.human_attribute_name(:created_at), resource: resource) %>
     <% end %>
     <% component.with_field do |c| %>

--- a/config/locales/models/product/en-GB.yml
+++ b/config/locales/models/product/en-GB.yml
@@ -4,6 +4,7 @@ en-GB:
     attributes:
       product:
         brand: Brand
+        category: Category
         created_at: Created At
         image_file_name: Image
         item_description: Description

--- a/config/locales/views/products/en-GB.yml
+++ b/config/locales/views/products/en-GB.yml
@@ -12,6 +12,7 @@ en-GB:
     resource:
       description: A product that is sold in the PurchasePlus master catalogue
       invalid_message:
+        category: A category must be selected.
         item_description: A description must be entered.
         item_measure: A measure must be entered.
         item_sell_pack_name: A sell pack name must be entered.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
     resources :audits, only: %i[index]
   end
 
-  resources :users, only: %i[show edit update], concerns: %i[audited]
+  resources :users, only: %i[index show edit update], concerns: %i[audited]
 
   resources :tasks
   resources :products, shallow: true, except: %i[new create], concerns: %i[audited] do

--- a/test/components/resource_form_tree_select_component_test.rb
+++ b/test/components/resource_form_tree_select_component_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ResourceForm::TreeSelectComponentTest < ViewComponent::TestCase
+  def setup
+    @resource = products(:lager)
+  end
+
+  test 'with a selected value' do
+    render_inline(ResourceForm::FieldComponent.new) do |component|
+      component.with_attribute_tree_select(
+        root_class: External::Category,
+        attribute: :category_id,
+        label: 'Categories',
+        resource: @resource,
+        hidden: false,
+        options: { readonly: false }
+      )
+    end
+
+    assert_selector("#product_#{@resource.id}_category_id--label", text: 'Categories')
+    assert_selector("#product_#{@resource.id}_category_id--input[value=\"Brewskis\"]")
+    assert_selector("#product_#{@resource.id}_category_id--hidden-input[value=\"#{@resource.category_id}\"]", visible: false)
+    assert_selector("#product_#{@resource.id}_category_id--button")
+  end
+
+  test 'without a selected value' do
+    @resource.category_id = nil
+    render_inline(ResourceForm::FieldComponent.new) do |component|
+      component.with_attribute_tree_select(
+        root_class: External::Category,
+        attribute: :category_id,
+        label: 'Categories',
+        resource: @resource,
+        hidden: false,
+        options: { readonly: false }
+      )
+    end
+
+    assert_no_selector("span#product_#{@resource.id}_category_id--#{@resource.category_id}-checkmark")
+  end
+
+  test 'readonly mode' do
+    render_inline(ResourceForm::FieldComponent.new) do |component|
+      component.with_attribute_tree_select(
+        root_class: External::Category,
+        attribute: :category_id,
+        label: 'Categories',
+        resource: @resource,
+        hidden: false,
+        options: { readonly: true }
+      )
+    end
+
+    assert_no_selector("#product_#{@resource.id}_category_id--button")
+  end
+
+  test 'with help text' do
+    render_inline(ResourceForm::FieldComponent.new) do |component|
+      component.with_attribute_tree_select(
+        root_class: External::Category,
+        attribute: :category_id,
+        label: 'Categories',
+        resource: @resource,
+        options: { readonly: false, help: 'This is some help' }
+      )
+    end
+
+    assert_selector("#product_#{@resource.id}_category_id--help", text: 'This is some help')
+  end
+end

--- a/test/components/stories/resource_form/tree_select_component_stories.rb
+++ b/test/components/stories/resource_form/tree_select_component_stories.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module ResourceForm
+  class TreeSelectComponentStories < ApplicationStories
+    story :basic do
+      constructor(
+        root_class: External::Category,
+        attribute: 'category_id',
+        label: 'Category',
+        resource: klazz(Product),
+        options: { readonly: false }
+      )
+    end
+
+    story :readonly do
+      constructor(
+        root_class: External::Category,
+        attribute: 'category_id',
+        label: 'Category',
+        resource: klazz(Product, category_id: External::Category.find_by(name: 'Bagels').id),
+        options: { readonly: true }
+      )
+    end
+
+    story :selected do
+      constructor(
+        root_class: External::Category,
+        attribute: 'category_id',
+        label: 'Category',
+        resource: klazz(Product, category_id: External::Category.find_by(name: 'Bagels').id),
+        options: { readonly: false }
+      )
+    end
+  end
+end

--- a/test/fixtures/external/categories.yml
+++ b/test/fixtures/external/categories.yml
@@ -1,0 +1,10 @@
+_fixture:
+  model_class: External::Category
+
+booze:
+  name: Booze
+  parent: nil
+
+brewskis:
+  name: Brewskis
+  parent: booze

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -37,6 +37,7 @@ lager:
   item_pack_name: bottle
   item_sell_quantity: 6
   item_sell_pack_name: carton
+  category: brewskis
 
 apple:
   external_product: apple


### PR DESCRIPTION
Changes:
* Add a tree select component that can be used to render a tree of options. Only supports 2 levels currently. No search facility.

<img width="475" alt="image" src="https://user-images.githubusercontent.com/88665458/204291795-f03bb3bc-2425-4545-a4dd-bdf228f5dd45.png">
